### PR TITLE
Fix >=g++13 compilation with include cstdint

### DIFF
--- a/sw/fdcanusb_daemon.cc
+++ b/sw/fdcanusb_daemon.cc
@@ -37,6 +37,7 @@
 #include <unistd.h>
 #include <termios.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>


### PR DESCRIPTION
Had errors compiling with g++13 because of cstdint (https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes). Fixed it with #include \<cstdint\>